### PR TITLE
chore: configure Dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,44 +1,43 @@
-# Dependabot configuration for automatic dependency updates
 version: 2
 updates:
-  # Enable version updates for npm
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "04:00"
+      time: "09:30"
+      timezone: "Europe/Paris"
     open-pull-requests-limit: 10
-    pull-request-branch-name:
-      separator: "/"
+    assignees:
+      - "glandais"
     commit-message:
-      prefix: "chore"
-      prefix-development: "chore"
+      prefix: "deps(npm)"
       include: "scope"
     labels:
       - "dependencies"
-      - "npm"
-    assignees:
-      - "glandais"
     groups:
-      # Group all minor and patch updates together
       minor-and-patch:
         update-types:
           - "minor"
           - "patch"
 
-  # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "04:00"
+      time: "10:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    assignees:
+      - "glandais"
     commit-message:
-      prefix: "ci"
+      prefix: "deps(github-actions)"
       include: "scope"
     labels:
       - "dependencies"
-      - "github-actions"
-    assignees:
-      - "glandais"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Standardizes `.github/dependabot.yml` to match the tribly reference standard.

## Ecosystems configured

- **npm** (`/`): weekly on monday at 09:30 Europe/Paris, limit 10, grouped minor+patch
- **github-actions** (`/`): weekly on monday at 10:00 Europe/Paris, limit 5, grouped minor+patch

## Changes from previous config

- Fixed schedule times (04:00 → 09:30 for npm, 04:00 → 10:00 for github-actions)
- Updated commit prefixes to `deps(npm)` and `deps(github-actions)` (were `chore`/`ci`)
- Removed extra labels (`npm`, `github-actions`) — only `dependencies` label is used
- Added `timezone: "Europe/Paris"` to both blocks
- Added `open-pull-requests-limit: 5` and `groups` block to github-actions
- Removed non-standard `pull-request-branch-name` and `prefix-development` keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)